### PR TITLE
Fix NameError on macOS: defer ctypes.wintypes type annotation

### DIFF
--- a/audacity_mcp/audacity_client.py
+++ b/audacity_mcp/audacity_client.py
@@ -78,7 +78,7 @@ class AudacityClient:
         except OSError as e:
             raise AudacityMCPError(ErrorCode.PIPE_OPEN_FAILED, str(e))
 
-    def _win32_open_pipe(self, pipe_path: str, access: int) -> ctypes.wintypes.HANDLE:
+    def _win32_open_pipe(self, pipe_path: str, access: int) -> "ctypes.wintypes.HANDLE":
         for _ in range(3):
             handle = kernel32.CreateFileW(
                 pipe_path,


### PR DESCRIPTION
## Summary

Fixes #2

- Fixes `NameError: name 'ctypes' is not defined` when importing `audacity_mcp` on macOS/Linux
- The `ctypes` module is conditionally imported only on Windows (`sys.platform == "win32"`), but the return type annotation `-> ctypes.wintypes.HANDLE` on `_win32_open_pipe` is evaluated at class definition time on all platforms
- Uses a string annotation (`"ctypes.wintypes.HANDLE"`) to defer evaluation, allowing the class to load on non-Windows platforms

## Reproduction

```
$ audacity-mcp
Traceback (most recent call last):
  File "/opt/homebrew/bin/audacity-mcp", line 5, in <module>
    from audacity_mcp.main import main
  ...
  File ".../audacity_mcp/audacity_client.py", line 81, in AudacityClient
    def _win32_open_pipe(self, pipe_path: str, access: int) -> ctypes.wintypes.HANDLE:
NameError: name 'ctypes' is not defined
```

## Environment

- macOS (Apple Silicon)
- Python 3.10
- `audacity-mcp` installed via pip

🤖 Generated with [Claude Code](https://claude.com/claude-code)