### PR TITLE
Fix pipe paths on macOS: use actual user ID instead of hardcoded 0

### DIFF
--- a/audacity_mcp_shared/constants.py
+++ b/audacity_mcp_shared/constants.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -7,8 +8,9 @@ class PipePaths:
         TO_SRV = r"\\.\pipe\ToSrvPipe"
         FROM_SRV = r"\\.\pipe\FromSrvPipe"
     else:
-        TO_SRV = "/tmp/audacity_script_pipe.to.0"
-        FROM_SRV = "/tmp/audacity_script_pipe.from.0"
+        _uid = os.getuid()
+        TO_SRV = f"/tmp/audacity_script_pipe.to.{_uid}"
+        FROM_SRV = f"/tmp/audacity_script_pipe.from.{_uid}"
 
 
 class Timeouts:


### PR DESCRIPTION
## Summary

Fixes pipe connection failure on macOS where user ID is not 0.

- Audacity creates named pipes using the current UID (e.g. audacity_script_pipe.to.501), but PipePaths hardcodes .to.0 / .from.0
- This causes PIPE_OPEN_FAILED: No such file or directory: /tmp/audacity_script_pipe.from.0
- Uses os.getuid() to dynamically resolve the correct pipe paths

## Environment

- macOS (Apple Silicon)
- Python 3.10
- User ID 501 (standard macOS user)

Generated with Claude Code